### PR TITLE
Make BigInt.fromString a bit more strict

### DIFF
--- a/benchmarks/elm-package.json
+++ b/benchmarks/elm-package.json
@@ -12,7 +12,8 @@
         "BrianHicks/elm-benchmark": "1.0.2 <= v < 2.0.0",
         "elm-community/list-extra": "6.1.0 <= v < 7.0.0",
         "elm-community/result-extra": "2.2.0 <= v < 3.0.0",
-        "elm-lang/core": "5.1.1 <= v < 6.0.0"
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "rtfeldman/hex": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "1.0.2",
     "summary": "unlimited size integers",
     "repository": "https://github.com/hickscorp/elm-bigint.git",
     "license": "MIT",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.1",
+    "version": "2.0.0",
     "summary": "unlimited size integers",
     "repository": "https://github.com/hickscorp/elm-bigint.git",
     "license": "MIT",

--- a/src/BigInt.elm
+++ b/src/BigInt.elm
@@ -193,19 +193,31 @@ fromString : String -> Maybe BigInt
 fromString x =
     case String.toList x of
         [] ->
-            Just zero
+            Nothing
+
+        '-' :: '0' :: 'x' :: [] ->
+            Nothing
 
         '-' :: '0' :: 'x' :: xs ->
             fromHexString_ xs
                 |> Maybe.map (mul (fromInt -1))
 
+        '-' :: [] ->
+            Nothing
+
         '-' :: xs ->
             fromString_ xs
                 |> Maybe.map (mkBigInt Negative)
 
+        '+' :: [] ->
+            Nothing
+
         '+' :: xs ->
             fromString_ xs
                 |> Maybe.map (mkBigInt Positive)
+
+        '0' :: 'x' :: [] ->
+            Nothing
 
         '0' :: 'x' :: xs ->
             fromHexString_ xs

--- a/src/BigInt.elm
+++ b/src/BigInt.elm
@@ -187,7 +187,16 @@ fromInt x =
         |> normalise
 
 
-{-| Makes an BigInt from a String
+{-| Makes an BigInt from a Integer or Hex String, positive or negative
+
+    fromString "123" == Just (BigInt.Pos ...)
+    fromString "0x456" == Just (BigInt.Pos ...)
+    fromString "-123" == Just (BigInt.Neg ...)
+    fromString "-0x123" == Just (BigInt.Neg ...)
+    fromString "" == Nothing
+    fromString "0x" == Nothing
+    fromString "this is not a number :P" == Nothing
+
 -}
 fromString : String -> Maybe BigInt
 fromString x =

--- a/tests/BigIntTests.elm
+++ b/tests/BigIntTests.elm
@@ -114,6 +114,22 @@ fromTests =
                         BigInt.mul midLargeInt midLargeInt
                 in
                     Expect.equal fromString (Just fromInt)
+        , test "fromString 0x0 = fromInt 0" <|
+            \_ -> Expect.equal (BigInt.fromString "0x0") (Just <| BigInt.fromInt 0)
+        , test "fromString -0x0 = fromInt 0" <|
+            \_ -> Expect.equal (BigInt.fromString "0x0") (Just <| BigInt.fromInt 0)
+        , test "fromString 0 = fromInt 0" <|
+            \_ -> Expect.equal (BigInt.fromString "0x0") (Just <| BigInt.fromInt 0)
+        , test "fromString \"\" = Nothing" <|
+            \_ -> Expect.equal (BigInt.fromString "") Nothing
+        , test "fromString + = Nothing" <|
+            \_ -> Expect.equal (BigInt.fromString "+") Nothing
+        , test "fromString - = Nothing" <|
+            \_ -> Expect.equal (BigInt.fromString "-") Nothing
+        , test "fromString 0x = Nothing" <|
+            \_ -> Expect.equal (BigInt.fromString "0x") Nothing
+        , test "fromString -0x = Nothing" <|
+            \_ -> Expect.equal (BigInt.fromString "-0x") Nothing
         ]
 
 

--- a/tests/BigIntTests.elm
+++ b/tests/BigIntTests.elm
@@ -117,9 +117,9 @@ fromTests =
         , test "fromString 0x0 = fromInt 0" <|
             \_ -> Expect.equal (BigInt.fromString "0x0") (Just <| BigInt.fromInt 0)
         , test "fromString -0x0 = fromInt 0" <|
-            \_ -> Expect.equal (BigInt.fromString "0x0") (Just <| BigInt.fromInt 0)
+            \_ -> Expect.equal (BigInt.fromString "-0x0") (Just <| BigInt.fromInt 0)
         , test "fromString 0 = fromInt 0" <|
-            \_ -> Expect.equal (BigInt.fromString "0x0") (Just <| BigInt.fromInt 0)
+            \_ -> Expect.equal (BigInt.fromString "0") (Just <| BigInt.fromInt 0)
         , test "fromString \"\" = Nothing" <|
             \_ -> Expect.equal (BigInt.fromString "") Nothing
         , test "fromString + = Nothing" <|


### PR DESCRIPTION
`BigInt.fromString "", "-", "+", "-0x", and "0x"` currently return `Just Zer`. A good argument can be made for why all such strings should be considered invalid, and thus return `Nothing`.

I bumped the major version as well. Even though this isn't a breaking API change from a semantic versioning perspective, this PR makes things previously valid now invalid, and could cause breakages for people.

There's a chance elm-package will not accept the major version bump, as it's type checker will see that no major changes have been made.

PS - Added better `fromString` examples in docs, as it was not obvious hex was a valid input.